### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thoda-dev/nuxt-ollama/security/code-scanning/10](https://github.com/thoda-dev/nuxt-ollama/security/code-scanning/10)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to both `lint` and `test` jobs without changing behavior.  
For this workflow, the minimal required permission is:

- `contents: read`

Place this block after the `on:` trigger section and before `jobs:`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
